### PR TITLE
Rearrange attractor display

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -4,12 +4,6 @@
 
 $state-danger-text: red;
 
-@mixin box_sizing {
-  -moz-box-sizing:    border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing:         border-box;
-}
-
 /* Generic styles */
 
 .primary-color {

--- a/app/javascript/components/Attractor/TweakAttractor.jsx
+++ b/app/javascript/components/Attractor/TweakAttractor.jsx
@@ -39,8 +39,8 @@ const TweakAttractor = ({cacheId, className, coefficients, startXy}) => {
             showEquation={false}
             startXy={tweakedStartXy}
             initialCount={30000}
-            width={300}
-            height={300}
+            width={250}
+            height={250}
           />
         </div>
       ))}

--- a/app/javascript/components/Attractor/index.jsx
+++ b/app/javascript/components/Attractor/index.jsx
@@ -68,6 +68,12 @@ const Attractor = ({className, coefficients, initialCount, showEquation, startXy
 
   return (
     <>
+      <canvas
+        ref={canvasEl}
+        width={width}
+        height={height}
+        className={className}
+      />
       {showEquation && (
         <Equation
           coefficients={coefficients}
@@ -75,12 +81,6 @@ const Attractor = ({className, coefficients, initialCount, showEquation, startXy
           className="mb-3"
         />
       )}
-      <canvas
-        ref={canvasEl}
-        width={width}
-        height={height}
-        className={className}
-      />
     </>
   );
 };

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -19,11 +19,9 @@ export default () => {
     <div className="primary-color d-flex flex-column align-items-center justify-content-center">
       <header className="container secondary-color text-center">
         <h1 className="display-4">Strange Attractors</h1>
-        <p className="lead">
-          Math is beautiful!
-        </p>
       </header>
       <section>
+        <hr className="my-2" />
         <div className="d-flex justify-content-center">
           <button
             className="btn btn-primary mx-2"

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -24,7 +24,7 @@ export default () => {
         </p>
       </header>
       <section>
-        <div className="flex mb-4">
+        <div className="d-flex justify-content-center">
           <button
             className="btn btn-primary mx-2"
             onClick={() => {
@@ -35,7 +35,7 @@ export default () => {
             Next saved attractor
           </button>
           <button
-            className="btn btn-outline-primary mx-2"
+            className="btn btn-primary mx-2"
             onClick={() => {
               setTweakMode(false);
               const attractorPoints = findInterestingCoefficients();
@@ -44,8 +44,11 @@ export default () => {
           >
             Generate new attractor
           </button>
+        </div>
+        <hr className="my-2" />
+        <div className="d-flex justify-content-center mb-4">
           <button
-            className="btn btn-outline-primary mx-2"
+            className="btn btn-sm btn-outline-primary mx-2"
             onClick={() => {
               setTweakMode(true);
               setCacheId(prev => prev + 1);

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -17,60 +17,59 @@ export default () => {
 
   return (
     <div className="primary-color d-flex flex-column align-items-center justify-content-center">
-      <header className="container secondary-color text-center">
-        <h1 className="display-4">Strange Attractors</h1>
-      </header>
-      <section>
-        <hr className="my-2" />
-        <div className="d-flex justify-content-center">
-          <button
-            className="btn btn-primary mx-2"
-            onClick={() => {
-              setTweakMode(false);
-              setCoefficientsIdx(prevIdx => (prevIdx + 1) % someGoodAttractors.length);
-            }}
-          >
-            Next saved attractor
-          </button>
-          <button
-            className="btn btn-primary mx-2"
-            onClick={() => {
-              setTweakMode(false);
-              const attractorPoints = findInterestingCoefficients();
-              setAttractorPointProps(attractorPoints);
-            }}
-          >
-            Generate new attractor
-          </button>
-        </div>
-        <hr className="my-2" />
-        <div className="d-flex justify-content-center mb-4">
-          <button
-            className="btn btn-sm btn-outline-primary mx-2"
-            onClick={() => {
-              setTweakMode(true);
-              setCacheId(prev => prev + 1);
-            }}
-          >
-            Tweak this attractor
-          </button>
-        </div>
-        {
-          tweakMode
-            ? (
-              <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
-            ) : (
-              <Attractor
-                {...attractorPointProps}
-                showEquation={true}
-                className="mb-3"
-                initialCount={45000}
-                width={500}
-                height={500}
-              />
-            )
-        }
+      <section className="d-flex w-100">
+        <div className="sidebar d-flex flex-column justify-content-start flex-grow-0 p-2">
+          <div className="d-flex flex-column justify-content-center border-bottom py-2">
+            <button
+              className="btn btn-outline-primary m-2"
+              onClick={() => {
+                setTweakMode(false);
+                setCoefficientsIdx(prevIdx => (prevIdx + 1) % someGoodAttractors.length);
+              }}
+            >
+              Next saved attractor
+            </button>
+            <button
+              className="btn btn-outline-primary m-2"
+              onClick={() => {
+                setTweakMode(false);
+                const attractorPoints = findInterestingCoefficients();
+                setAttractorPointProps(attractorPoints);
+              }}
+            >
+              Generate new attractor
+            </button>
+          </div>{/* /page controls */}
+          <div className="d-flex flex-column justify-content-center mb-4 py-2">
+            <button
+              className="btn btn-outline-primary m-2"
+              onClick={() => {
+                setTweakMode(true);
+                setCacheId(prev => prev + 1);
+              }}
+            >
+              Tweak this attractor
+            </button>
+          </div>{/* /attractor controls */}
+        </div>{/* /sidebar */}
+        <main className="flex-grow-1 d-flex flex-column justify-content-start align-content-center p-2">
+          {
+            tweakMode
+              ? (
+                <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
+              ) : (
+                <Attractor
+                  {...attractorPointProps}
+                  showEquation={true}
+                  className="mb-3"
+                  initialCount={45000}
+                  width={500}
+                  height={500}
+                />
+              )
+          }
+        </main>
       </section>
-    </div>
+    </div>// /page container
   );
 };

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -21,7 +21,7 @@ export default () => {
         <div className="sidebar d-flex flex-column justify-content-start flex-grow-0 p-2">
           <div className="d-flex flex-column justify-content-center border-bottom py-2">
             <button
-              className="btn btn-outline-primary m-2"
+              className="btn btn-secondary m-2"
               onClick={() => {
                 setTweakMode(false);
                 setCoefficientsIdx(prevIdx => (prevIdx + 1) % someGoodAttractors.length);
@@ -30,7 +30,7 @@ export default () => {
               Next saved attractor
             </button>
             <button
-              className="btn btn-outline-primary m-2"
+              className="btn btn-secondary m-2"
               onClick={() => {
                 setTweakMode(false);
                 const attractorPoints = findInterestingCoefficients();
@@ -42,7 +42,7 @@ export default () => {
           </div>{/* /page controls */}
           <div className="d-flex flex-column justify-content-center mb-4 py-2">
             <button
-              className="btn btn-outline-primary m-2"
+              className="btn btn-secondary m-2"
               onClick={() => {
                 setTweakMode(true);
                 setCacheId(prev => prev + 1);

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -17,58 +17,60 @@ export default () => {
 
   return (
     <div className="primary-color d-flex flex-column align-items-center justify-content-center">
-      <div className="container secondary-color text-center">
+      <header className="container secondary-color text-center">
         <h1 className="display-4">Strange Attractors</h1>
         <p className="lead">
           Math is beautiful!
         </p>
-      </div>
-      {
-        tweakMode
-          ? (
-            <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
-          ) : (
-            <Attractor
-              {...attractorPointProps}
-              showEquation={true}
-              className="mb-3"
-              initialCount={45000}
-              width={500}
-              height={500}
-            />
-          )
-      }
+      </header>
+      <section>
+        {
+          tweakMode
+            ? (
+              <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
+            ) : (
+              <Attractor
+                {...attractorPointProps}
+                showEquation={true}
+                className="mb-3"
+                initialCount={45000}
+                width={500}
+                height={500}
+              />
+            )
+        }
 
-      <div className="flex mb-4">
-        <button
-          className="btn btn-primary mx-2"
-          onClick={() => {
-            setTweakMode(false);
-            setCoefficientsIdx(prevIdx => (prevIdx + 1) % someGoodAttractors.length);
-          }}
-        >
-          Next saved attractor
-        </button>
-        <button
-          className="btn btn-outline-primary mx-2"
-          onClick={() => {
-            setTweakMode(false);
-            const attractorPoints = findInterestingCoefficients();
-            setAttractorPointProps(attractorPoints);
-          }}
-        >
-          Generate new attractor
-        </button>
-        <button
-          className="btn btn-outline-primary mx-2"
-          onClick={() => {
-            setTweakMode(true);
-            setCacheId(prev => prev + 1);
-          }}
-        >
-          Tweak this attractor
-        </button>
-      </div>
+        <div className="flex mb-4">
+          <button
+            className="btn btn-primary mx-2"
+            onClick={() => {
+              setTweakMode(false);
+              setCoefficientsIdx(prevIdx => (prevIdx + 1) % someGoodAttractors.length);
+            }}
+          >
+            Next saved attractor
+          </button>
+          <button
+            className="btn btn-outline-primary mx-2"
+            onClick={() => {
+              setTweakMode(false);
+              const attractorPoints = findInterestingCoefficients();
+              setAttractorPointProps(attractorPoints);
+            }}
+          >
+            Generate new attractor
+          </button>
+          <button
+            className="btn btn-outline-primary mx-2"
+            onClick={() => {
+              setTweakMode(true);
+              setCacheId(prev => prev + 1);
+            }}
+          >
+            Tweak this attractor
+          </button>
+        </div>
+      </section>
     </div>
   );
 };

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -24,22 +24,6 @@ export default () => {
         </p>
       </header>
       <section>
-        {
-          tweakMode
-            ? (
-              <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
-            ) : (
-              <Attractor
-                {...attractorPointProps}
-                showEquation={true}
-                className="mb-3"
-                initialCount={45000}
-                width={500}
-                height={500}
-              />
-            )
-        }
-
         <div className="flex mb-4">
           <button
             className="btn btn-primary mx-2"
@@ -70,6 +54,21 @@ export default () => {
             Tweak this attractor
           </button>
         </div>
+        {
+          tweakMode
+            ? (
+              <TweakAttractor cacheId={cacheId} {...attractorPointProps} className="mb-3" />
+            ) : (
+              <Attractor
+                {...attractorPointProps}
+                showEquation={true}
+                className="mb-3"
+                initialCount={45000}
+                width={500}
+                height={500}
+              />
+            )
+        }
       </section>
     </div>
   );


### PR DESCRIPTION
Old version:
> ![Screenshot_061820_070504_PM](https://user-images.githubusercontent.com/8515899/85089111-9e768680-b196-11ea-8bad-e8a7e5810e61.jpg)

New version:
> ![Screenshot_061920_082858_AM](https://user-images.githubusercontent.com/8515899/85150078-edf49b00-b206-11ea-94f8-755ddd0d64b0.jpg)

It doesn't look great when tweaking an attractor if the page is < ~968px wide, but I can live with this for now until I get around to a responsive grid for the tweaked attractors:
> ![Screenshot_061920_083309_AM](https://user-images.githubusercontent.com/8515899/85150534-825efd80-b207-11ea-967b-7f00b44e3351.jpg)


There was this intermediate version, that was an improvement over the original, but I ultimately decided it was still too tall, so I switched to the design above that has the controls in a sidebar.
> ![Screenshot_061820_081249_PM](https://user-images.githubusercontent.com/8515899/85093092-16957a00-b1a0-11ea-8c24-bcf6b5fbe465.jpg)
