### PR TITLE
Stop stretching attractor canvas

### DIFF
--- a/app/javascript/components/Attractor/index.jsx
+++ b/app/javascript/components/Attractor/index.jsx
@@ -68,12 +68,14 @@ const Attractor = ({className, coefficients, initialCount, showEquation, startXy
 
   return (
     <>
-      <canvas
-        ref={canvasEl}
-        width={width}
-        height={height}
-        className={className}
-      />
+      <div class="d-flex justify-content-center">
+        <canvas
+          ref={canvasEl}
+          width={width}
+          height={height}
+          className={className}
+        />
+      </div>
       {showEquation && (
         <Equation
           coefficients={coefficients}


### PR DESCRIPTION
I thought it was ok, but I really don't like it after seeing it a few times.

Before:
> ![Screenshot_061920_112326_PM](https://user-images.githubusercontent.com/8515899/85195002-e1625800-b283-11ea-8a97-7a1fe5807058.jpg)

After:
> ![Screenshot_061920_112353_PM](https://user-images.githubusercontent.com/8515899/85195015-f0e1a100-b283-11ea-9b8d-f508829b8b4c.jpg)

This is obviously still not great. Way too much white space. In the future I'll want to resize and repaint the canvas at different breakpoints.