### PR TITLE
Set up password reset emails

### DIFF
--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,19 @@ class PasswordResetsController < ApplicationController
   def new
   end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "Email sent with password reset instructions"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "Email address not found"
+      render 'new'
+    end
+  end
+
   def edit
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -29,10 +29,16 @@ class PasswordResetsController < ApplicationController
       @user.errors.add(:password, :blank)
       render 'edit'
     elsif @user.update(user_params)
+      # One likely scenario for users unfortunate enough to have sessions stolen would be to
+      # immediately reset their passwords. As a result, it would be especially nice if password
+      # reset automatically expired any such hijacked sessions.
+      @user.forget
       reset_session
       log_in @user
       flash[:success] = "Password has been reset."
       redirect_to @user
+      # We don't set the password_reset_digest to nil because if the user ever clicks on the
+      # link again, we still want to be able to show them the "link expired" message.
     else
       render 'edit'
     end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+
   def new
   end
 
@@ -16,5 +19,15 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit
+  end
+
+  # Before filters
+  private def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  private def valid_user
+    # TODO: Flash message if we have to redirect
+    redirect_to root_url unless @user&.authenticated?(:password_reset, params[:id])
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -35,10 +35,9 @@ class PasswordResetsController < ApplicationController
       @user.forget
       reset_session
       log_in @user
+      @user.update_columns(password_reset_digest: nil, password_reset_sent_at: nil)
       flash[:success] = "Password has been reset."
       redirect_to @user
-      # We don't set the password_reset_digest to nil because if the user ever clicks on the
-      # link again, we still want to be able to show them the "link expired" message.
     else
       render 'edit'
     end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -5,7 +5,7 @@ class PasswordResetsController < ApplicationController
   def create
     @user = User.find_by(email: params[:password_reset][:email].downcase)
     if @user
-      @user.create_reset_digest
+      @user.create_password_reset_digest
       @user.send_password_reset_email
       flash[:info] = "Email sent with password reset instructions"
       redirect_to root_url

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -9,7 +9,7 @@ module SessionsHelper
     user_id = cookies.encrypted[:user_id]
     if user_id
       user = User.find_by(id: user_id)
-      if user&.authenticated?(cookies[:remember_token])
+      if user&.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'strange.chaos.attractors@gmail.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,8 +8,6 @@ class UserMailer < ApplicationMailer
   def password_reset(user)
     subject = "Password reset for Chaos Attractors" # TODO maybe make a constant for the site title?
     @user = user
-    @greeting = "Hi, #{user.name}"
-
     mail to: user.email, subject: subject
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,9 +5,11 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
+  def password_reset(user)
+    subject = "Password reset for Chaos Attractors" # TODO maybe make a constant for the site title?
+    @user = user
+    @greeting = "Hi, #{user.name}"
 
-    mail to: "to@example.org"
+    mail to: user.email, subject: subject
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,9 +33,10 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  def authenticated?(password)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(password)
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false unless digest.present?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   def remember

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
+  attr_accessor :remember_token, :password_reset_token
 
   before_save { email.downcase! }
   validates :email,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,14 @@ class User < ApplicationRecord
   has_many :attractors, dependent: :destroy
 
   def self.digest(str)
+    # The password digest is created using bcrypt (via has_secure_password), so we’ll need to use
+    # the same method for creating digests manually. The secure password source code uses:
+    # `BCrypt::Password.create(string, cost: cost)` where string is the string to be hashed and cost
+    # is the cost parameter that determines the computational cost to calculate the hash. Using a
+    # high cost makes it computationally intractable to use the hash to determine the original
+    # password, which is an important security precaution in a production environment, but in tests
+    # we want the digest method to be as fast as possible. The secure password source code has a
+    # line for this as well, which we'll use (below).
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
     BCrypt::Password.create(str, cost: cost)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,4 +60,8 @@ class User < ApplicationRecord
   def send_password_reset_email
     UserMailer.password_reset(self).deliver_now
   end
+
+  def password_reset_expired?
+    password_reset_sent_at < 2.hours.ago
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,4 +48,16 @@ class User < ApplicationRecord
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  def create_password_reset_digest
+    self.password_reset_token = User.new_token
+    update_columns(
+      password_reset_digest: User.digest(password_reset_token),
+      password_reset_sent_at: Time.zone.now,
+    )
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,13 +21,17 @@ class User < ApplicationRecord
     BCrypt::Password.create(str, cost: cost)
   end
 
-  def authenticated?(token)
+  def self.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  def authenticated?(password)
     return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(token)
+    BCrypt::Password.new(remember_digest).is_password?(password)
   end
 
   def remember
-    self.remember_token = SecureRandom.urlsafe_base64
+    self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,20 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, 'Reset password') %>
+<div class="primary-color d-flex flex-column justify-content-center pt-4">
+  <header class="container secondary-color text-center">
+    <h1 class="display-4 mb-4">Reset password</h1>
+  </header>
+  <section class="primary-color d-flex flex-column align-items-stretch justify-content-center mx-5 px-5">
+    <%= form_with(model: @user, url: password_reset_path(params[:id]), local: true) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <div class="form-group">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'form-control' %>
+      </div>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,14 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<% provide(:title, 'Forgot password') %>
+<div class="primary-color d-flex flex-column justify-content-center pt-4">
+  <header class="container secondary-color text-center">
+    <h1 class="display-4 mb-4">Forgot password</h1>
+  </header>
+  <section class="primary-color d-flex flex-column align-items-stretch justify-content-center mx-5 px-5">
+    <%= form_with(url: password_resets_path, scope: :password_reset, local: true) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary mt-3" %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -5,8 +5,10 @@
   </header>
   <section class="primary-color d-flex flex-column align-items-stretch justify-content-center mx-5 px-5">
     <%= form_with(url: request_reset_password_path, scope: :password_reset, local: true) do |f| %>
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 'form-control' %>
+      </div>
 
       <%= f.submit "Submit", class: "btn btn-primary mt-3" %>
     <% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -4,7 +4,7 @@
     <h1 class="display-4 mb-4">Forgot password</h1>
   </header>
   <section class="primary-color d-flex flex-column align-items-stretch justify-content-center mx-5 px-5">
-    <%= form_with(url: password_resets_path, scope: :password_reset, local: true) do |f| %>
+    <%= form_with(url: request_reset_password_path, scope: :password_reset, local: true) do |f| %>
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -12,6 +12,7 @@
 
       <div class="form-group">
         <%= f.label :password %>
+        <%= link_to "(forgot password)", new_password_reset_path %>
         <%= f.password_field :password, class: "form-control" %>
       </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -12,7 +12,7 @@
 
       <div class="form-group">
         <%= f.label :password %>
-        <%= link_to "(forgot password)", new_password_reset_path %>
+        <%= link_to "(forgot password)", request_reset_password_path %>
         <%= f.password_field :password, class: "form-control" %>
       </div>
 

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,10 @@
-<h1>User#password_reset</h1>
+<p>
+  <%= @greeting %>,
+</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+  Click the link below to reset your Chaos Attractors password. If you didn’t request to reset your
+  password, you can ignore this email, or reply if you think something is wrong.
 </p>
+
+<p>TODO: include link</p>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,10 +1,12 @@
-<p>
-  <%= @greeting %>,
-</p>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.password_reset_token, email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  Click the link below to reset your Chaos Attractors password. If you didn’t request to reset your
-  password, you can ignore this email, or reply if you think something is wrong.
+  If you did not request your password to be reset, please ignore this email and
+  your password will stay as it is.
 </p>
-
-<p>TODO: include link</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,6 +1,8 @@
-<%= @greeting %>,
+To reset your password click the link below:
 
-Click the link below to reset your Chaos Attractors password. If you didn’t request to reset your
-password, you can ignore this email, or reply if you think something is wrong.
+<%= edit_password_reset_url(@user.password_reset_token, email: @user.email) %>
 
-TODO: include link
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,6 @@
-User#password_reset
+<%= @greeting %>,
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+Click the link below to reset your Chaos Attractors password. If you didn’t request to reset your
+password, you can ignore this email, or reply if you think something is wrong.
+
+TODO: include link

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,22 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  # I'm not sure if it's preferable to use the herokuapp url or our custom url. If we use the latter, we might
+  # also have to update the ActionMailer::Base.smtp_settings[:domain] below.
+  host = 'quiet-stream-72579.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    enable_starttls_auto: true
+  }
+
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
+  resources :password_resets, only: [:new, :create, :edit, :update]
 
   # Attractors
   get '/attractors/featured/random', to: 'attractors#random_featured'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
-  resources :password_resets, only: [:new, :create, :edit, :update]
+  get '/request-reset-password', to: 'password_resets#new'
+  post '/request-reset-password', to: 'password_resets#create'
+  resources :password_resets, only: [:edit, :update]
 
   # Attractors
   get '/attractors/featured/random', to: 'attractors#random_featured'

--- a/db/migrate/20200627224300_add_password_reset_to_users.rb
+++ b/db/migrate/20200627224300_add_password_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddPasswordResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :password_reset_digest, :string
+    add_column :users, :password_reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_045126) do
+ActiveRecord::Schema.define(version: 2020_06_27_224300) do
 
   create_table "attractors", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2020_06_18_045126) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false, null: false
+    t.string "password_reset_digest"
+    t.datetime "password_reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,11 +1,9 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
-
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
     user = User.first
     user.password_reset_token = User.new_token
     UserMailer.password_reset(user)
   end
-
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -3,7 +3,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.password_reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -4,6 +4,7 @@ class UserMailerPreview < ActionMailer::Preview
   def password_reset
     user = User.first
     user.password_reset_token = User.new_token
+    user.update_attribute(:password_reset_digest, User.digest(user.password_reset_token))
     UserMailer.password_reset(user)
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
Add password-reset feature. Screenshots below.

Note: For sendgrid setup, I also followed these instructions that aren't reflected in the code:

> Now that we’ve got account activations working in development, in this section we’ll configure our application so that it can actually send email in production. We’ll first get set up with a free service to send email, and then configure and deploy our application.
>
> To send email in production, we’ll use SendGrid, which is available as an add-on at Heroku for verified accounts. (This requires adding credit card information to your Heroku account, but there is no charge when verifying an account.) For our purposes, the “starter” tier (which as of this writing is limited to 400 emails a day but costs nothing) is the best fit. We can add it to our app as follows:
>
> `$ heroku addons:create sendgrid:starter`

Add "forgot pw" link to login screen:
> ![Screenshot_062720_072108_PM](https://user-images.githubusercontent.com/8515899/85935992-61537800-b8ab-11ea-9b4e-4a4f91b2f952.jpg)

Add page for requesting a pw reset:
> ![Screenshot_062720_072158_PM](https://user-images.githubusercontent.com/8515899/85936001-78926580-b8ab-11ea-8eb1-c815e9c2afdf.jpg)

Add email with pw reset link:
> ![Screenshot_062720_072236_PM](https://user-images.githubusercontent.com/8515899/85936010-8f38bc80-b8ab-11ea-9cf6-82fb58b74ad9.jpg)

Add page for changing your password:
> ![Screenshot_062720_072335_PM](https://user-images.githubusercontent.com/8515899/85936029-b2636c00-b8ab-11ea-89ac-2bdfb3536495.jpg)
