### PR TITLE
Fix prod email sending

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,8 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
+  host = 'quiet-stream-72579.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
     port: ENV['MAILGUN_SMTP_PORT'],
     address: ENV['MAILGUN_SMTP_SERVER'],
@@ -74,6 +76,7 @@ Rails.application.configure do
     authentication: :plain,
   }
   ActionMailer::Base.delivery_method = :smtp
+  # heroku config:set MAILGUN_SMTP_PORT=587 MAILGUN_SMTP_SERVER=smtp.mailgun.org MAILGUN_SMTP_LOGIN=postmaster@sandbox2f490537d8024c849dd7ddd5c86e582d.mailgun.org MAILGUN_SMTP_PASSWORD="68d981e4c638b8c1fb37d012157a0c3f-468bde97-569e87fa"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   host = 'quiet-stream-72579.herokuapp.com'
-  config.action_mailer.default_url_options = { host: host }
+  config.action_mailer.default_url_options[:host] = host
   ActionMailer::Base.smtp_settings = {
     port: ENV['MAILGUN_SMTP_PORT'],
     address: ENV['MAILGUN_SMTP_SERVER'],
@@ -76,7 +76,6 @@ Rails.application.configure do
     authentication: :plain,
   }
   ActionMailer::Base.delivery_method = :smtp
-  # heroku config:set MAILGUN_SMTP_PORT=587 MAILGUN_SMTP_SERVER=smtp.mailgun.org MAILGUN_SMTP_LOGIN=postmaster@sandbox2f490537d8024c849dd7ddd5c86e582d.mailgun.org MAILGUN_SMTP_PASSWORD="68d981e4c638b8c1fb37d012157a0c3f-468bde97-569e87fa"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   host = 'quiet-stream-72579.herokuapp.com'
   config.action_mailer.default_url_options = { host: host, protocol: "https" }
+  Rails.application.routes.default_url_options = { host: host, protocol: "https" }
   ActionMailer::Base.smtp_settings = {
     port: ENV['MAILGUN_SMTP_PORT'],
     address: ENV['MAILGUN_SMTP_SERVER'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   host = 'quiet-stream-72579.herokuapp.com'
-  config.action_mailer.default_url_options[:host] = host
+  config.action_mailer.default_url_options = { host: host, protocol: "https" }
   ActionMailer::Base.smtp_settings = {
     port: ENV['MAILGUN_SMTP_PORT'],
     address: ENV['MAILGUN_SMTP_SERVER'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,21 +65,15 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
-  # I'm not sure if it's preferable to use the herokuapp url or our custom url. If we use the latter, we might
-  # also have to update the ActionMailer::Base.smtp_settings[:domain] below.
-  host = 'quiet-stream-72579.herokuapp.com'
-  config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    address: 'smtp.sendgrid.net',
-    port: '587',
+    port: ENV['MAILGUN_SMTP_PORT'],
+    address: ENV['MAILGUN_SMTP_SERVER'],
+    user_name: ENV['MAILGUN_SMTP_LOGIN'],
+    password: ENV['MAILGUN_SMTP_PASSWORD'],
+    domain: 'quiet-stream-72579.heroku.com',
     authentication: :plain,
-    user_name: ENV['SENDGRID_USERNAME'],
-    password: ENV['SENDGRID_PASSWORD'],
-    domain: 'heroku.com',
-    enable_starttls_auto: true
   }
-
+  ActionMailer::Base.delivery_method = :smtp
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
Sendgrid account is having issues. I contacted support, and also tried these steps:
> when you add the send grid add on to Heroku, it creates two environment/config variables.
>
> I suggest that you go to this URL https://app.sendgrid.com/login and try to log in with these credentials.
>
> Your account might be locked because you did not verify your email at sendgrid end, which a required step. Once you do that it should be work.

But I still wasn't able to log in. While I wait for Sendgrid's response, I'm trying Mailgun.

Update: Mailgun is set up correctly. Some of the stuff setting "host" in this PR might be superfluous; I got it to work, and haven't tested which parts might be redundant and can be removed.

I still can't send to Mailgun without setting up a custom domain, and I'm having billing issues with them.