### PR TITLE
Display attractors in /users page

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -38,6 +38,10 @@ $state-danger-text: red;
   .user:last-child {
     border-bottom: none;
   }
+
+  .user-profile__attractor__container {
+    border: none;
+  }
 }
 
 /* User page */

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,10 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.paginate(page: params[:page], per_page: 10)
+    @users = User.left_outer_joins(:attractors)
+                 .group(:id)
+                 .order("count(attractors.id) > 0 DESC")
+                 .paginate(page: params[:page], per_page: 10)
   end
 
   def show

--- a/app/views/attractors/_attractor.html.erb
+++ b/app/views/attractors/_attractor.html.erb
@@ -1,12 +1,10 @@
 <div class="user-profile__attractor__container">
-  <%= react_component("Attractor/index", { coefficients: attractor.details["coefficients"],
-                                           startXy: attractor.details["startXy"],
-                                           showEquation: false,
-                                           initialCount: initialCount,
-                                           width: width, height: height,
-                                           id: attractor.id,
-                                           canDelete: attractor.user_id == current_user.id }) %>
-  <p class="mb-0">
-    <%= link_to attractor.user.name, attractor.user %> | Discovered <%= time_ago_in_words(attractor.created_at) %> ago.
-  </p>
+  <%= react_component("Attractor/index", {
+    coefficients: attractor.details["coefficients"],
+    startXy: attractor.details["startXy"],
+    showEquation: false,
+    initialCount: initialCount,
+    width: width, height: height,
+    id: attractor.id,
+    canDelete: canDelete && attractor.user_id == current_user.id }) %>
 </div>

--- a/app/views/attractors/_attractor.html.erb
+++ b/app/views/attractors/_attractor.html.erb
@@ -2,8 +2,8 @@
   <%= react_component("Attractor/index", { coefficients: attractor.details["coefficients"],
                                            startXy: attractor.details["startXy"],
                                            showEquation: false,
-                                           initialCount: 30000,
-                                           width: 300, height: 300,
+                                           initialCount: initialCount,
+                                           width: width, height: height,
                                            id: attractor.id,
                                            canDelete: attractor.user_id == current_user.id }) %>
   <p class="mb-0">

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,6 +1,10 @@
 <div class="user">
   <%= link_to user.name, user %>
+  <div class="d-flex justify-content-between">
+    <%= render user.attractors.sample(3), height: 150, width: 150, initialCount: 7500, canDelete: false %>
+  </div>
   <% if current_user.admin? && !current_user?(user) %>
-    | <%= link_to "delete", user, method: :delete, data: { confirm: "You sure?" } %>
+    <br>
+      <%= link_to "delete", user, method: :delete, data: { confirm: "You sure?" } %>
   <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
       <h3 class="mb-3">Attractors (<%= @user.attractors.count %>)</h3>
       <%= will_paginate @attractors %>
       <div class="attractors d-flex flex-column">
-        <%= render @attractors, height: 300, width: 300, initialCount: 30000 %>
+        <%= render @attractors, height: 300, width: 300, initialCount: 30000, canDelete: true %>
       </div>
       <%= will_paginate @attractors %>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
       <h3 class="mb-3">Attractors (<%= @user.attractors.count %>)</h3>
       <%= will_paginate @attractors %>
       <div class="attractors d-flex flex-column">
-        <%= render @attractors %>
+        <%= render @attractors, height: 300, width: 300, initialCount: 30000 %>
       </div>
       <%= will_paginate @attractors %>
     <% end %>


### PR DESCRIPTION
It looks a little weird when the user has exactly 2 attractors, but I'm not too worried about it right now.
> ![Screenshot_062820_040852_PM](https://user-images.githubusercontent.com/8515899/85960613-a9c96f00-b959-11ea-9e19-3c88b29e0707.jpg)
